### PR TITLE
Allowing WHCMS install on Domain Subfolders

### DIFF
--- a/src/Adapter/GuzzleHttpAdapter.php
+++ b/src/Adapter/GuzzleHttpAdapter.php
@@ -80,7 +80,6 @@ class GuzzleHttpAdapter implements ConnectorInterface
     private function getAdapter()
     {
         return new Client([
-            'base_uri' => $this->config['apiurl'],
             'timeout' => 30,
             'form_params' => array_merge(
                 Arr::get($this->config, $this->config['auth_type']),

--- a/src/Adapter/GuzzleHttpAdapter.php
+++ b/src/Adapter/GuzzleHttpAdapter.php
@@ -3,9 +3,9 @@
 namespace DarthSoup\Whmcs\Adapter;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use GuzzleHttp\ClientInterface;
 
 /**
  * Class GuzzleHttpAdapter.

--- a/src/WhmcsManager.php
+++ b/src/WhmcsManager.php
@@ -2,9 +2,9 @@
 
 namespace DarthSoup\Whmcs;
 
+use DarthSoup\Whmcs\Adapter\ConnectorInterface;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Contracts\Config\Repository;
-use DarthSoup\Whmcs\Adapter\ConnectorInterface;
 
 /**
  * Class WhmcsManager.
@@ -50,7 +50,7 @@ class WhmcsManager
         $parameters['action'] = $method;
 
         try {
-            $url = $this->getConfig()['apiurl'] . '/api.php';
+            $url = $this->getConfig()['apiurl'].'/api.php';
             $response = $this->connection()->post($url, [
                 'form_params' => array_merge($parameters, $this->connection()->getConfig()['form_params']),
             ]);

--- a/src/WhmcsManager.php
+++ b/src/WhmcsManager.php
@@ -50,7 +50,8 @@ class WhmcsManager
         $parameters['action'] = $method;
 
         try {
-            $response = $this->connection()->post('api.php', [
+            $url = $this->getConfig()['apiurl'] . '/api.php';
+            $response = $this->connection()->post($url, [
                 'form_params' => array_merge($parameters, $this->connection()->getConfig()['form_params']),
             ]);
 


### PR DESCRIPTION
Guzzle `base_uri` does not allow subfolder to be used.