### PR TITLE
fixed double api.php in url when complete url is provided

### DIFF
--- a/src/WhmcsManager.php
+++ b/src/WhmcsManager.php
@@ -50,7 +50,11 @@ class WhmcsManager
         $parameters['action'] = $method;
 
         try {
-            $url = $this->getConfig()['apiurl'].'/api.php';
+            $url = $this->getConfig()['apiurl'];
+            if (!preg_match('/\/api\.php$/i', $url)) {
+                $url = rtrim($url, '/') . '/api.php';
+            }
+
             $response = $this->connection()->post($url, [
                 'form_params' => array_merge($parameters, $this->connection()->getConfig()['form_params']),
             ]);


### PR DESCRIPTION
Hello,

There are couple of way to fix the problem mentioned in issue #19 (double api.php in the url if you set a complete URL for WHMCS_API_URL). I chose to keep backward compatibility for older projects by simply checking if the the URL contains `/api.php` at the end of the URL. If not, we just append it. That's solving the problem on my side and it's clearer now that WHMCS_API_URL can contain a real URL and not the includes path. 