### PR TITLE
fixed double api.php in url when complete url is provided - legacy

### DIFF
--- a/src/WhmcsManager.php
+++ b/src/WhmcsManager.php
@@ -50,7 +50,11 @@ class WhmcsManager
         $parameters['action'] = $method;
 
         try {
-            $url = $this->getConfig()['apiurl'].'/api.php';
+            $url = $this->getConfig()['apiurl'];
+            if (!preg_match('/\/api\.php$/i', $url)) {
+                $url = rtrim($url, '/') . '/api.php';
+            }
+
             $response = $this->connection()->post($url, [
                 'form_params' => array_merge($parameters, $this->connection()->getConfig()['form_params']),
             ]);


### PR DESCRIPTION
Hello

Here is the fix I made for main branch applied to the legacy branch (https://github.com/darthsoup/laravel-whmcs/pull/21).