### PR TITLE
Refactor to add "getClient" method in WhmcsFactory

### DIFF
--- a/src/WhmcsFactory.php
+++ b/src/WhmcsFactory.php
@@ -22,7 +22,7 @@ class WhmcsFactory
 
     public function make(array $config): Client
     {
-        $client = new Client($this->getBuilder($config));
+        $client = $this->getClient($this->getBuilder($config));
 
         if (!array_key_exists('method', $config)) {
             throw new InvalidArgumentException('The whmcs factory requires an auth method.');
@@ -50,5 +50,10 @@ class WhmcsFactory
         }
 
         return $builder;
+    }
+    
+    protected function getClient(Builder $builder): Client
+    {
+        return new Client($builder);
     }
 }


### PR DESCRIPTION
This simple PR adds a `getClient()` method in `WhmcsFactory`.

This is useful, as it makes it easier to extend the `Client` with additional API methods in a subclass.

For example, a service provider could then be written like this, to add the `System::getStats()` method:

```PHP
use DarthSoup\Whmcs\WhmcsFactory;
use DarthSoup\WhmcsApi\Api\System;
use DarthSoup\WhmcsApi\Client;
use DarthSoup\WhmcsApi\HttpClient\Builder;
use Illuminate\Contracts\Foundation\Application;


$this->app->singleton('whmcs.factory', function (Application $app) {
    return new class ($app['whmcs.authfactory']) extends WhmcsFactory {
        protected function getClient(Builder $builder): Client
        {
            return new class ($builder) extends Client {
                public function system(): System
                {
                    return new class($this) extends System {
                        public function getStats()
                        {
                            return $this->send('GetStats');
                        }
                    };
                }
            };
        }
    };
});
```