### PR TITLE
feat: add http client timeout config options

### DIFF
--- a/config/whmcs.php
+++ b/config/whmcs.php
@@ -48,5 +48,19 @@ return [
             'access_key' => env('WHMCS_API_ACCESSKEY')
         ],
 
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Timeout Settings
+    |--------------------------------------------------------------------------
+    |
+    | Set the connection timeout and general timeout in seconds for the HTTP
+    | client below, integer values only.
+    |
+    */
+
+    'connect_timeout' => 10,
+
+    'timeout' => 30,
 ];

--- a/src/WhmcsServiceProvider.php
+++ b/src/WhmcsServiceProvider.php
@@ -50,11 +50,14 @@ class WhmcsServiceProvider extends ServiceProvider
      */
     protected function registerHttpClientFactory(): void
     {
-        $this->app->singleton('whmcs.httpclientfactory', function () {
+        $this->app->singleton('whmcs.httpclientfactory', function (Container $app) {
             $psrFactory = new PsrHttpFactory();
 
             return new HttpClientBuilderFactory(
-                new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]),
+                new GuzzleClient([
+                    'connect_timeout' => $app['config']->get('whmcs.connect_timeout', 10),
+                    'timeout' => $app['config']->get('whmcs.timeout', 30),
+                ]),
                 $psrFactory,
                 $psrFactory,
                 $psrFactory,


### PR DESCRIPTION
Giving the option to set a different `connect_timeout` and `timeout` should it be needed.